### PR TITLE
fix: rename misleading Average Prompt label to Total Prompt Chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,10 +208,10 @@ Shows AI vs human coding attribution from WakaTime, aggregated across all your p
 👤 Written by Hand:        8,721 lines
 📊 AI Contribution:        58.6%
 🔤 Tokens In / Out:        1.2M / 3.4M
-💬 Average Prompt:         142 chars
+💬 Total Prompt Chars:     484.8K chars
 ```
 
-> 💡 **Note:** The block is hidden entirely when no AI activity is reported (no GenAI integration, or zero AI usage in the range), so you won't see a section full of zeros. `Avg Prompt Length` is weighted by `ai_input_tokens` across projects.
+> 💡 **Note:** The block is hidden entirely when no AI activity is reported (no GenAI integration, or zero AI usage in the range), so you won't see a section full of zeros. The prompt row shows `Total Prompt Chars` (raw `ai_prompt_length` from WakaTime) today; once WakaTime exposes `ai_average_prompt_length` at top-level, the row switches to `Average Prompt`.
 
 The title adapts to `WAKATIME_RANGE` so the timeframe is clear at a glance:
 

--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -179,9 +179,9 @@ func MakeCodingStreakList(s *wakatime.AllTimeSinceTodayStats, currentStreak, lon
 // MakeAIStatsList returns a summary of AI vs human coding attribution from WakaTime.
 // Returns an empty string when there is no AI activity to display, so the block is hidden entirely.
 //
-// The "Average Prompt" row prefers avgPrompt (doc-defined ai_average_prompt_length) and
-// falls back to promptLength (ai_prompt_length) while the avg field is missing in API
-// responses. The row is omitted when neither value is populated.
+// The prompt row prefers avgPrompt (doc-defined ai_average_prompt_length) and renders it
+// as "Average Prompt"; otherwise it falls back to promptLength (ai_prompt_length, a raw
+// total) and renders it as "Total Prompt Chars". The row is omitted when both are zero.
 func MakeAIStatsList(aiAdd, humanAdd, inTokens, outTokens, promptLength int64, avgPrompt float64, wakaRange string) string {
 	if aiAdd == 0 && inTokens == 0 {
 		return ""
@@ -198,17 +198,17 @@ func MakeAIStatsList(aiAdd, humanAdd, inTokens, outTokens, promptLength int64, a
 		aiContribution = float64(aiAdd) / float64(totalAdd) * 100
 	}
 
-	// TODO(wakatime-api): drop the promptLength fallback once WakaTime ships
-	// ai_average_prompt_length at top-level. Today's API returns only ai_prompt_length
-	// (a raw total, not an average), so we display the total under the "Average Prompt"
-	// label as a stop-gap. When avgPrompt becomes non-zero, this branch becomes unreachable
-	// in practice and the whole switch can collapse to a single avgPrompt assignment.
-	var promptValue int64
+	// TODO(wakatime-api): drop the promptLength branch and revert the row label to
+	// "Average Prompt" once WakaTime ships ai_average_prompt_length at top-level.
+	// Today's API returns only ai_prompt_length (a raw total, not an average), so we
+	// surface it under a distinct "Total Prompt Chars" label to avoid the misleading
+	// "Average Prompt" reading.
+	var promptRow string
 	switch {
 	case avgPrompt > 0:
-		promptValue = int64(math.Round(avgPrompt))
+		promptRow = fmt.Sprintf("💬 Average Prompt:         %s chars\n", humanizeCount(int64(math.Round(avgPrompt))))
 	case promptLength > 0:
-		promptValue = promptLength
+		promptRow = fmt.Sprintf("💬 Total Prompt Chars:     %s chars\n", humanizeCount(promptLength))
 	}
 
 	var b strings.Builder
@@ -218,9 +218,7 @@ func MakeAIStatsList(aiAdd, humanAdd, inTokens, outTokens, promptLength int64, a
 	fmt.Fprintf(&b, "👤 Written by Hand:        %s lines\n", addCommas(int(humanAdd)))
 	fmt.Fprintf(&b, "📊 AI Contribution:        %.1f%%\n", aiContribution)
 	fmt.Fprintf(&b, "🔤 Tokens In / Out:        %s / %s\n", humanizeCount(inTokens), humanizeCount(outTokens))
-	if promptValue > 0 {
-		fmt.Fprintf(&b, "💬 Average Prompt:         %s chars\n", humanizeCount(promptValue))
-	}
+	b.WriteString(promptRow)
 	b.WriteString("```\n\n")
 
 	return b.String()

--- a/pkg/writer/writer_test.go
+++ b/pkg/writer/writer_test.go
@@ -155,7 +155,7 @@ func TestMakeAIStatsList(t *testing.T) {
 			},
 		},
 		{
-			name:         "Average Prompt falls back to ai_prompt_length when avg is zero",
+			name:         "Total Prompt Chars falls back to ai_prompt_length when avg is zero",
 			aiAdd:        12340,
 			humanAdd:     8721,
 			inTokens:     1_200_000,
@@ -165,8 +165,9 @@ func TestMakeAIStatsList(t *testing.T) {
 			contains: []string{
 				"AI Contribution:        58.6%",
 				"Tokens In / Out:        1.2M / 3.4M",
-				"Average Prompt:         484.8K chars",
+				"Total Prompt Chars:     484.8K chars",
 			},
+			notContains: []string{"Average Prompt:"},
 		},
 		{
 			name:      "small token counts use addCommas; prompt row hidden when both zero",
@@ -176,7 +177,7 @@ func TestMakeAIStatsList(t *testing.T) {
 			contains: []string{
 				"Tokens In / Out:        999 / 0",
 			},
-			notContains: []string{"Average Prompt:"},
+			notContains: []string{"Average Prompt:", "Total Prompt Chars:"},
 		},
 		{
 			name:      "title shows weekly variant for last_7_days",


### PR DESCRIPTION
WakaTime's API returns ai_prompt_length as a raw total, not an average, so display it under a distinct label until ai_average_prompt_length is exposed at top-level.